### PR TITLE
Export top-level modules using __all__

### DIFF
--- a/RsInstrument/__init__.py
+++ b/RsInstrument/__init__.py
@@ -1,11 +1,10 @@
 """VISA communication interface for SCPI-based instrument remote control.
-    :version: 1.120.1
-    :copyright: 2025 by Rohde & Schwarz GMBH & Co. KG
-    :license: MIT, see LICENSE for more details.
+:version: 1.120.1
+:copyright: 2025 by Rohde & Schwarz GMBH & Co. KG
+:license: MIT, see LICENSE for more details.
 """
 
-
-__version__ = '1.120.1'
+__version__ = "1.120.1"
 
 # Main class
 from RsInstrument.RsInstrument import RsInstrument
@@ -17,7 +16,14 @@ from RsInstrument.RsInstrument import BinFloatFormat, BinIntFormat
 from RsInstrument.Internal.InstrumentSettings import OpcSyncQueryMechanism
 
 # Exceptions
-from RsInstrument.Internal.InstrumentErrors import RsInstrException, TimeoutException, StatusException, UnexpectedResponseException, ResourceError, DriverValueError
+from RsInstrument.Internal.InstrumentErrors import (
+    RsInstrException,
+    TimeoutException,
+    StatusException,
+    UnexpectedResponseException,
+    ResourceError,
+    DriverValueError,
+)
 
 # Callback Event Argument prototypes
 from RsInstrument.Internal.IoTransferEventArgs import IoTransferEventArgs
@@ -26,5 +32,27 @@ from RsInstrument.Internal.IoTransferEventArgs import IoTransferEventArgs
 from RsInstrument.Internal.ScpiLogger import LoggingMode
 
 # Utilities
-from RsInstrument.Internal.Utilities import size_to_kb_mb_gb_string, size_to_kb_mb_string
+from RsInstrument.Internal.Utilities import (
+    size_to_kb_mb_gb_string,
+    size_to_kb_mb_string,
+)
 from RsInstrument.Internal.Utilities import value_to_si_string
+
+
+__all__ = [
+    "RsInstrument",
+    "BinIntFormat",
+    "BinFloatFormat",
+    "TimeoutException",
+    "IoTransferEventArgs",
+    "LoggingMode",
+    "StatusException",
+    "ResourceError",
+    "size_to_kb_mb_string",
+    "size_to_kb_mb_gb_string",
+    "value_to_si_string",
+    "RsInstrException",
+    "OpcSyncQueryMechanism",
+    "UnexpectedResponseException",
+    "DriverValueError",
+]


### PR DESCRIPTION
I noticed `py.typed` was added in 1.120.1 and my pyright configuration complained that the top level modules are not explicitly exported. This is a tiny pull request to add those.

Cheers!